### PR TITLE
Stop using absolute times in HTTP/2 per-thread test

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -1041,7 +1041,7 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
             urllib3.http2.extract_from_urllib3()
 
     def test_http2_probe_blocked_per_thread(self) -> None:
-        state, current_thread, last_action = None, None, time.monotonic()
+        state, current_thread, last_action = None, None, time.perf_counter()
 
         def connect_callback(label: str, thread_id: int, **kwargs: typing.Any) -> None:
             nonlocal state, current_thread, last_action
@@ -1052,8 +1052,8 @@ class BaseTestHTTPS(HTTPSHypercornDummyServerTestCase):
 
             # Since we're trying to connect to TARPIST_HOST, all connections will
             # fail, but they should be tried one after the other
-            now = time.monotonic()
-            assert now > last_action
+            now = time.perf_counter()
+            assert now >= last_action
             last_action = now
 
             if label == "before connect":


### PR DESCRIPTION
Here's a suggestion for a more robust version of a test that has been plaguing #3324. The idea is that with locking, a precise sequence of events must happen. We still look at the time, but only to make sure that events happen in a specific sequence. That way, even on a super slow CI host, the test should succeed. I can see myself placing callbacks in more places when we implement more HTTP/2 things.

The downside is that it clutters connection.py. But I don't think it's going to slow things down for users, as it's only adding a few ifs.