### PR TITLE
Fix coverage in _HTTP2ProbeCache.acquire_and_get

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,8 @@ cryptography==42.0.4
 backports.zoneinfo==0.2.1;python_version<"3.9"
 towncrier==23.6.0
 pytest-memray==1.5.0;python_version<"3.13" and sys_platform!="win32" and implementation_name=="cpython"
-trio==0.25.0
+attrs==23.2.0  # https://github.com/python-trio/trio/issues/3053
+trio==0.26.0
 Quart==0.19.4
 quart-trio==0.11.1
 # https://github.com/pgjones/hypercorn/issues/62


### PR DESCRIPTION
@sethmlarson @illia-v I spent way too many hours trying to fix the last coverage issue in urllib3/urllib3#3324 when I could have added a `Defensive:` comment. However, the idea was also to understand how this issue could be triggered. The code in question looks like this:

```python3
value = None
try:
    value = operation()
except BaseException:
    if value is not None:
        lock.release()
    raise
```

The test modifies `operation()` to raise an exception, but then that means `lock.release()` can never be called in the test, because `value` is never set. Which made me wonder: why are we checking if value is set? If the exception does happen before it's set, we should still release the lock, right?

I'm happy to *not* add the test, but think this question should be resolved before merging.